### PR TITLE
Support des colonnes JSON dans les filters

### DIFF
--- a/data-filter/CHANGELOG.md
+++ b/data-filter/CHANGELOG.md
@@ -1,0 +1,19 @@
+# DataFilter - Change log
+
+All notable changes to the @recursyve/nestjs-data-filter project will be documented in this file. (starting from the 8.0.0 version)
+
+## [8.0.0] - 2022-02-05
+
+### Added
+
+- Upgrade @nestjs dependencies to 8.x.x
+
+### Changed
+
+- Added support for the new access control structure of @recursyve/nestjs-access-control
+
+## [8.1.0] - 2022-03-04
+
+### Added
+
+- Support for JSON column in filters [#43](https://github.com/Recursyve/nestjs-librairies/pull/43)

--- a/data-filter/lib/filter/filters/filter.ts
+++ b/data-filter/lib/filter/filters/filter.ts
@@ -296,13 +296,7 @@ export abstract class Filter implements FilterDefinition {
             return this.transformForJsonArray(rule, name);
         }
 
-        const colName = this.path ? Sequelize.col(name) : Sequelize.literal(name);
-        const value = SequelizeUtils.generateWhereValue(rule);
-        if (this.json.path) {
-            return Sequelize.where(Sequelize.fn("JSON_EXTRACT", colName, this.json.path), value as LogicType);
-        }
-
-        return Sequelize.where(Sequelize.fn("JSON_EXTRACT", colName), value as LogicType);
+        return this.transformForJsonObject(rule, name);
     }
 
     private transformForJsonArray(rule: QueryRuleModel, name: string): WhereOptions {
@@ -324,5 +318,15 @@ export abstract class Filter implements FilterDefinition {
         }
 
         return null;
+    }
+
+    private transformForJsonObject(rule: QueryRuleModel, name: string): WhereOptions {
+        const colName = this.path ? Sequelize.col(name) : Sequelize.literal(name);
+        const value = SequelizeUtils.generateWhereValue(rule);
+        if (this.json.path) {
+            return Sequelize.where(Sequelize.fn("JSON_EXTRACT", colName, this.json.path), value as LogicType);
+        }
+
+        return Sequelize.where(Sequelize.fn("JSON_EXTRACT", colName), value as LogicType);
     }
 }

--- a/data-filter/package.json
+++ b/data-filter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@recursyve/nestjs-data-filter",
-    "version": "8.0.0",
+    "version": "8.0.1",
     "description": "NestJs DataFilter library",
     "main": "index.js",
     "scripts": {

--- a/data-filter/package.json
+++ b/data-filter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@recursyve/nestjs-data-filter",
-    "version": "8.0.1",
+    "version": "8.1.0",
     "description": "NestJs DataFilter library",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
On supporte maintenant les filtres sur les colonnes json. Le but est de pouvoir implémenter n'importe quel type de filter (SelectFilter, TextFilter, etc...), mais sur une partie d'un objet JSON.

### Exemple json array

```ts
export class MyFilter extends BaseFilter<MyFilterData> {
    public dataDefinition = MyFilterData;

    public client = new SelectFilter({
        attribute: "value",
        json: {
            type: "array"
        },
        values: async () => [{ id: "test", name: "Test!" }]
    }).setOperators(FilterOperatorTypes.Contains, FilterOperatorTypes.NotContains);
}
```

Dans cette définition, on dit que la colonne value est un colonne json et que ce json est un tableau. Le filtrer sera donc capable de faire un JSON_CONTAINS afin de regarder si une row de la base de donnée contain une certaine valeur dans son array.

### Exemple json object
```ts
export class MyFilter extends BaseFilter<MyFilterData> {
    public dataDefinition = MyFilterData;

    public client = new TextFilter({
        attribute: "value",
        json: {
            type: "object",
            path: "name"
        }
    });
}
```

Dans cette définition, on dit que la colonne value est un colonne json et que qu'elle contient un objet dont nous voulons filtrer sur la propriété `name` de l'objet. Nous pouvons donc faire n'importe quel filtre de type texte sur la propriété `name` de cette colonne.