### PR TITLE
Added support for multiple orders

### DIFF
--- a/data-filter/lib/filter/filter.service.ts
+++ b/data-filter/lib/filter/filter.service.ts
@@ -599,25 +599,5 @@ export class FilterService<Data> {
 
     private getNonNestedOrderColumns(orders: OrderModel[]): string[] {
         return orders.filter(order => order.column && !order.column.includes(".")).map(order => order.column);
-
-        const columns = [];
-
-        if (!orders) return columns;
-
-        for (const order of orders) {
-            if (!order.column) continue;
-
-            const lastColSeparatorIndex = order.column.lastIndexOf(".");
-
-            if (lastColSeparatorIndex !== -1) {
-                const column = order.column.substring(lastColSeparatorIndex + 1);
-
-                if (column) {
-                    columns.push(column);
-                }
-            }
-        }
-
-        return columns;
     }
 }

--- a/data-filter/lib/filter/order-rules/enum.order-rule.spec.ts
+++ b/data-filter/lib/filter/order-rules/enum.order-rule.spec.ts
@@ -1,4 +1,4 @@
-import { Literal } from "sequelize/types/lib/utils";
+import { Literal } from "sequelize/types/utils";
 import { EnumOrderRule } from "./enum.order-rule";
 
 describe("EnumOrderRule", () => {

--- a/data-filter/lib/models/filter.model.ts
+++ b/data-filter/lib/models/filter.model.ts
@@ -20,7 +20,7 @@ export interface FilterQueryModel {
     page?: FilterPageMode;
     search?: FilterSearchModel;
     query?: QueryModel;
-    order?: OrderModel;
+    order?: OrderModel | OrderModel[];
     data?: object;
     groupBy?: string;
 }

--- a/data-filter/lib/scanners/sequelize-model.scanner.ts
+++ b/data-filter/lib/scanners/sequelize-model.scanner.ts
@@ -140,7 +140,7 @@ export class SequelizeModelScanner {
     }
 
     public getOrder(model: typeof Model, orderObj: OrderModel): Order {
-        if (!orderObj || !orderObj.column || orderObj.direction === "") {
+        if (!orderObj?.column || !orderObj.direction) {
             return;
         }
 

--- a/data-filter/package-lock.json
+++ b/data-filter/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@recursyve/nestjs-data-filter",
-  "version": "8.2.3",
+  "version": "8.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/data-filter/package.json
+++ b/data-filter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@recursyve/nestjs-data-filter",
-    "version": "8.3.3",
+    "version": "8.3.4",
     "description": "NestJs DataFilter library",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
This PR adds support for multiple orders.
This is still retro compatible with a single order object.

In order to have multiple orders, we need to pass an array of OrderModel. The objects will passed in the same order to sequelize.