### PR TITLE
Support distance custom attribute from a lat and lng

### DIFF
--- a/data-filter/lib/filter/filters/geo-bounds.filter.ts
+++ b/data-filter/lib/filter/filters/geo-bounds.filter.ts
@@ -39,8 +39,8 @@ export class GeoBoundsFilter extends Filter implements BaseGeoBoundsFilterDefini
         const point = this.attribute ??
             fn(
                 "Point",
-                this.path ? literal(SequelizeUtils.getLiteralFullName(this.latAttribute, this.path)) : this.latAttribute,
-                this.path ? literal(SequelizeUtils.getLiteralFullName(this.lngAttribute, this.path)) : this.lngAttribute
+                this.path ? literal(SequelizeUtils.getLiteralFullName(this.lngAttribute, this.path)) : this.lngAttribute,
+                this.path ? literal(SequelizeUtils.getLiteralFullName(this.latAttribute, this.path)) : this.latAttribute
             );
         return where(
             fn("ST_Contains", polygon, point),

--- a/data-filter/lib/models/distance.model.ts
+++ b/data-filter/lib/models/distance.model.ts
@@ -1,14 +1,24 @@
-import { CustomAttributesConfig } from "./custom-attributes.model";
 import { fn, literal, ProjectionAlias } from "sequelize";
 import { SequelizeUtils } from "../sequelize.utils";
+import { CustomAttributesConfig } from "./custom-attributes.model";
 
-export interface DistanceConfig {
-    attribute: string;
+export interface BaseDistanceConfig {
     coordinates: (option?) => [number, number];
     name: string;
     path?: string;
     srid?: number;
 }
+
+export interface DistanceConfigWithPoint {
+    attribute: string;
+}
+
+export interface DistanceConfigWithLatLng {
+    latAttribute: string;
+    lngAttribute: string;
+}
+
+export type DistanceConfig = BaseDistanceConfig & (DistanceConfigWithPoint | DistanceConfigWithLatLng);
 
 export class DistanceAttributesConfig implements CustomAttributesConfig<DistanceConfig> {
     public type = "distance";
@@ -33,8 +43,19 @@ export class DistanceAttributesConfig implements CustomAttributesConfig<Distance
             path = [path, this.config.path].filter(x => x).join(".");
         }
 
-        const name = path ? SequelizeUtils.getLiteralFullName(this.config.attribute, path) : this.config.attribute;
         const location = fn("ST_GeometryFromText", literal(`'POINT(${latitude} ${longitude})'`), this.config.srid ?? 0);
-        return [fn("ST_Distance_Sphere", literal(name), location), this.config.name ?? this.key];
+        return [fn("ST_Distance_Sphere", this.getPointAttribute(path), location), this.config.name ?? this.key];
+    }
+
+    private getPointAttribute(path: string) {
+        if ((this.config as DistanceConfigWithPoint).attribute) {
+            const att = (this.config as DistanceConfigWithPoint).attribute;
+            return literal(path ? SequelizeUtils.getLiteralFullName(att, path) : att);
+        }
+
+        const lat = path ? SequelizeUtils.getLiteralFullName((this.config as DistanceConfigWithLatLng).latAttribute, path) : (this.config as DistanceConfigWithLatLng).latAttribute;
+        const lng = path ? SequelizeUtils.getLiteralFullName((this.config as DistanceConfigWithLatLng).lngAttribute, path) : (this.config as DistanceConfigWithLatLng).lngAttribute;
+        const point = fn("Point", lng, lat);
+        return this.config.srid ? fn("ST_SRID", point, this.config.srid) : point;
     }
 }


### PR DESCRIPTION
We can now use the `@Distance` custom attribute without a point attribute

```ts
@Data(NiceModel)
@Distance({
    name: "distance",
    latAttribute: "latitude",
    lngAttribute: "longitude",
    coordinates: (options) => options.coordinates,
    srid: 4326
})
export class NiceModelData extends NiceModel {}
```

## Fix for GeoBoundsFilter

Fun fact, the `Point` in mysql takes the longitude first. 

```SQL
POINT(lng, lat)
```

instead of

```SQL
POINT(lat, lng)
```