### PR TITLE
[NestJsDataFilter] Date only filter

### DIFF
--- a/data-filter/lib/filter/filters/date-only.filter.ts
+++ b/data-filter/lib/filter/filters/date-only.filter.ts
@@ -1,0 +1,11 @@
+import { DateFilter } from "./date.filter";
+import { BaseFilterDefinition } from "./filter";
+
+export class DateOnlyFilter extends DateFilter {
+    constructor(definition: BaseFilterDefinition) {
+        super({
+            ...definition,
+            skipTimezone: true
+        });
+    }
+}

--- a/data-filter/lib/filter/filters/index.ts
+++ b/data-filter/lib/filter/filters/index.ts
@@ -1,5 +1,6 @@
 export * from "./coordinate.filter";
 export * from "./date.filter";
+export * from "./date-only.filter";
 export * from "./date-time.filter";
 export * from "./filter";
 export * from "./geo-localization.filter";

--- a/data-filter/package.json
+++ b/data-filter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@recursyve/nestjs-data-filter",
-    "version": "8.4.4",
+    "version": "8.4.5",
     "description": "NestJs DataFilter library",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
### New timezone setting for the DateFilter

The date filter transforms the received dates for the different operations. This is useful for datetime column.

Ex: If we want all resources created between January 1rst 2022 and December 31th 2022, we want the Query the be from the start of the day of January 1rst 2022 (0h 0m 0s) and the end of the day of December 31th 2022 (23h 59m 59s).

This behaviour works fine with datetime column, but it has a side effect for date only column. In some cases, it migth use the wrong date (date before or after) in the query because we do an unnecessary transformation.

To deal with this, the new setting `skipTimezone` was added to the `DateFilter`.

```ts
class MyFilter {
    public created = new DateFilter({
        attribute: "createdAt",
        skipTimezone: true
    });
}
```

### DateOnlyFilter

The `DateOnlyFilter` will automatically set the `skipTimezone` options to `true` for you.

```ts
class MyFilter {
    public created = new DateOnlyFilter({
        attribute: "createdAt"
    });
}
```