### PR TITLE
[AC] Fix access control guard for mongoose

### DIFF
--- a/access-control-mongoose/lib/decorators/access-control-resource.decorator.ts
+++ b/access-control-mongoose/lib/decorators/access-control-resource.decorator.ts
@@ -1,0 +1,11 @@
+import { SetMetadata } from "@nestjs/common";
+import { AccessControlResourceConfig } from "@recursyve/nestjs-access-control";
+import { ACCESS_CONTROL_RESOURCE } from "@recursyve/nestjs-access-control";
+
+export const MongooseAccessControlResource = (model: any, paramId = "id") => {
+    return SetMetadata(ACCESS_CONTROL_RESOURCE, {
+        model,
+        paramId,
+        type: "mongoose"
+    } as AccessControlResourceConfig);
+};

--- a/access-control-mongoose/lib/decorators/index.ts
+++ b/access-control-mongoose/lib/decorators/index.ts
@@ -2,3 +2,4 @@ export * from "./created-policy.decorator";
 export * from "./deleted-policy.decorator";
 export * from "./policy.decorator";
 export * from "./updated-policy.decorator";
+export * from "./access-control-resource.decorator";

--- a/access-control-mongoose/package-lock.json
+++ b/access-control-mongoose/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@recursyve/nestjs-access-control-mongoose",
-    "version": "8.0.0-beta.0",
+    "version": "8.0.0-beta.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2000,9 +2000,7 @@
             "dev": true
         },
         "@recursyve/nestjs-access-control": {
-            "version": "8.2.0-beta.0",
-            "resolved": "https://registry.npmjs.org/@recursyve/nestjs-access-control/-/nestjs-access-control-8.2.0-beta.0.tgz",
-            "integrity": "sha512-mj+izVaBsPUFs85zyFsE1neMTH+bwh0jMxoK42lshAg4E7qASafQknzJ6SWszQ3r0WpYvD5lRafl6BwCxsWeFQ==",
+            "version": "file:../access-control/dist",
             "dev": true
         },
         "@recursyve/nestjs-redis": {

--- a/access-control-sequelize/lib/decorators/access-control-resource.decorator.ts
+++ b/access-control-sequelize/lib/decorators/access-control-resource.decorator.ts
@@ -1,0 +1,11 @@
+import { SetMetadata } from "@nestjs/common";
+import { AccessControlResourceConfig } from "@recursyve/nestjs-access-control";
+import { ACCESS_CONTROL_RESOURCE } from "@recursyve/nestjs-access-control";
+
+export const SequelizeAccessControlResource = (model: any, paramId = "id") => {
+    return SetMetadata(ACCESS_CONTROL_RESOURCE, {
+        model,
+        paramId,
+        type: "sequelize"
+    } as AccessControlResourceConfig);
+};

--- a/access-control-sequelize/lib/decorators/index.ts
+++ b/access-control-sequelize/lib/decorators/index.ts
@@ -2,3 +2,4 @@ export * from "./created-policy.decorator";
 export * from "./deleted-policy.decorator";
 export * from "./policy.decorator";
 export * from "./updated-policy.decorator";
+export * from "./access-control-resource.decorator";

--- a/access-control-sequelize/package-lock.json
+++ b/access-control-sequelize/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@recursyve/nestjs-access-control-sequelize",
-    "version": "8.1.0-beta.1",
+    "version": "8.1.0-beta.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1076,9 +1076,7 @@
             "dev": true
         },
         "@recursyve/nestjs-access-control": {
-            "version": "8.2.0-beta.1",
-            "resolved": "https://registry.npmjs.org/@recursyve/nestjs-access-control/-/nestjs-access-control-8.2.0-beta.1.tgz",
-            "integrity": "sha512-bfEc6W+VUbt867+lW36cB7YJP6kzykSpzqLB0uXpKdBQEgTOvPBhIP+2WBe0qIKLjv6bvGMSZUjhCT488sRH4A==",
+            "version": "file:../access-control/dist",
             "dev": true
         },
         "@recursyve/nestjs-redis": {
@@ -1092,6 +1090,8 @@
         },
         "@recursyve/nestjs-sequelize-utils": {
             "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/@recursyve/nestjs-sequelize-utils/-/nestjs-sequelize-utils-8.0.3.tgz",
+            "integrity": "sha512-siLvfukWv4sIU/CE6/hYxaA7wPjoCUtOr0ruXc6rYgySRd3SEySaDe68ids4DvykD6CaCvcA6nJJhSUwSie4bw==",
             "dev": true
         },
         "@sinclair/typebox": {

--- a/access-control/lib/decorators/access-control-resource.decorator.ts
+++ b/access-control/lib/decorators/access-control-resource.decorator.ts
@@ -2,9 +2,10 @@ import { SetMetadata } from "@nestjs/common";
 import { AccessControlResourceConfig } from "../models/access-control-resource.model";
 import { ACCESS_CONTROL_RESOURCE } from "./constant";
 
-export const AccessControlResource = (model: any, paramId = "id") => {
+export const AccessControlResource = (model: any, paramId = "id", type?: string) => {
     return SetMetadata(ACCESS_CONTROL_RESOURCE, {
         model,
-        paramId
+        paramId,
+        type
     } as AccessControlResourceConfig);
 };

--- a/access-control/lib/decorators/index.ts
+++ b/access-control/lib/decorators/index.ts
@@ -7,3 +7,4 @@ export * from "./needs-access-actions.decorator";
 export * from "./policy.decorator";
 export * from "./updated-policy.decorator";
 export * from "./fallback-access-control-guards.decorator";
+export * from "./constant";

--- a/access-control/lib/guards/access-control.guard.ts
+++ b/access-control/lib/guards/access-control.guard.ts
@@ -48,17 +48,18 @@ export class AccessControlGuard implements CanActivate, OnModuleInit {
             request.resources = this.getModels(request.route.path, needsAccessActions);
         }
 
-        const getResource = (action: AccessAction, index: number) => {
+        // Returns the [resource, resourceType]
+        const getResource = (action: AccessAction, index: number): [any, string?] => {
             if (!controllerResource && !methodResource) {
-                return request.resources[index];
+                return [request.resources[index]];
             }
 
             if (controllerResource?.paramId === action.resourceIdParameterName) {
-                return controllerResource.model;
+                return [controllerResource.model, controllerResource.type];
             }
 
             if (methodResource?.paramId === action.resourceIdParameterName) {
-                return methodResource.model;
+                return [methodResource.model, methodResource.type];
             }
 
             return null;
@@ -69,12 +70,12 @@ export class AccessControlGuard implements CanActivate, OnModuleInit {
             getResource(x, i)
         ]);
 
-        for (const [accessAction, resource] of data) {
+        for (const [accessAction, [resource, resourceType]] of data) {
             if (!resource) {
                 return false;
             }
 
-            const resourceAccessControlService = this.accessControlService.forModel(resource);
+            const resourceAccessControlService = this.accessControlService.forModel(resource, resourceType);
             const accessRulesForUser = await resourceAccessControlService.getAccessRules(
                 user,
                 request.params[accessAction.resourceIdParameterName]

--- a/access-control/lib/models/access-control-resource.model.ts
+++ b/access-control/lib/models/access-control-resource.model.ts
@@ -1,4 +1,5 @@
 export interface AccessControlResourceConfig {
     model: any;
     paramId?: string;
+    type?: string;
 }

--- a/access-control/lib/models/index.ts
+++ b/access-control/lib/models/index.ts
@@ -5,3 +5,4 @@ export * from "./policy-config.model";
 export * from "./resources.model";
 export * from "./user-resources.model";
 export * from "./users.model";
+export * from "./access-control-resource.model";


### PR DESCRIPTION
The `AccessControlGuard` would always fallback on the default resource type for the resource service (usually `sequelize`), so routes with a mongoose resource would crash, since the mongoose object would be passed to the sequelize resource service.

In order to fix it, I added a `type` field to the `AccessControlResource` decorator.