### PR TITLE
[DATA-FILTER] Fix manually passing includes in find functions

### DIFF
--- a/data-filter/lib/data-filter.repository.ts
+++ b/data-filter/lib/data-filter.repository.ts
@@ -37,8 +37,8 @@ export class DataFilterRepository<Data> {
 
     public async findByPk(identifier: Identifier, options?: FindOptions, conditions?: object): Promise<Data> {
         const result = await this.model.findByPk(identifier, {
-            ...this.generateFindOptions(conditions),
-            ...(options ?? {})
+            ...(options ?? {}),
+            ...this.generateFindOptions(conditions)
         });
         if (!result) {
             return result as unknown as Data;
@@ -69,8 +69,8 @@ export class DataFilterRepository<Data> {
 
     public async findOne(options?: FindOptions, conditions?: object): Promise<Data> {
         const result = await this.model.findOne({
-            ...this.generateFindOptions(conditions),
-            ...(options ?? {})
+            ...(options ?? {}),
+            ...this.generateFindOptions(conditions)
         });
         if (!result) {
             return result as unknown as Data;
@@ -90,8 +90,8 @@ export class DataFilterRepository<Data> {
 
     public async findAll(options?: FindOptions, conditions?: object): Promise<Data[]> {
         const result = await this.model.findAll({
-            ...this.generateFindOptions(conditions),
-            ...(options ?? {})
+            ...(options ?? {}),
+            ...this.generateFindOptions(conditions)
         });
         if (!result?.length) {
             return result as unknown as Data[];


### PR DESCRIPTION
In most find functions, if we manually provide an `include` object to the `options`, it would first be merged with the provided data (using the `generateFindOptions` function), but then, the `options` spread would override the generated includes with the manual ones (provided in the `options` object.)

This behavior was already working in the `search` functions, but not in the other ones.
