### PR TITLE
[Data filter] Add support to inject data filter repositories

### DIFF
--- a/data-filter/lib/index.ts
+++ b/data-filter/lib/index.ts
@@ -30,7 +30,7 @@ export interface DataFilterConfig {
 }
 
 export interface DataFilterFeatureConfig extends DataFilterConfig {
-    filters: { filter: Type<BaseFilter<any>>; inject?: any[]; disableAccessControl?: boolean }[];
+    filters: { filter: Type<BaseFilter<any>>; inject?: any[]; disableAccessControl?: boolean; }[];
     repositories?: Function[];
 }
 

--- a/data-filter/lib/repositories/data-filter-repository.provider.ts
+++ b/data-filter/lib/repositories/data-filter-repository.provider.ts
@@ -1,0 +1,10 @@
+import { Provider } from "@nestjs/common";
+import { DataFilterService } from "../data-filter.service";
+import { getDataFilterRepositoryToken } from "./get-data-filter-repository.token";
+import { DataFilterRepositoryFactory } from "./repository.factory";
+
+export const createDataFilterRepositoryProvider = <T extends Function>(model: T): Provider => ({
+    provide: getDataFilterRepositoryToken(model),
+    useFactory: DataFilterRepositoryFactory({ model }),
+    inject: [DataFilterService],
+});

--- a/data-filter/lib/repositories/decorators/inject-data-filter-repository.decorator.ts
+++ b/data-filter/lib/repositories/decorators/inject-data-filter-repository.decorator.ts
@@ -1,0 +1,4 @@
+import { Inject } from "@nestjs/common";
+import { getDataFilterRepositoryToken } from "../get-data-filter-repository.token";
+
+export const InjectDataFilterRepository = <T extends Function>(data: T) => Inject(getDataFilterRepositoryToken(data));

--- a/data-filter/lib/repositories/get-data-filter-repository.token.ts
+++ b/data-filter/lib/repositories/get-data-filter-repository.token.ts
@@ -1,0 +1,1 @@
+export const getDataFilterRepositoryToken = <T extends Function>(data: T): string => `${data.name}FilterRepository`;

--- a/data-filter/lib/repositories/index.ts
+++ b/data-filter/lib/repositories/index.ts
@@ -1,0 +1,2 @@
+export * from "./decorators/inject-data-filter-repository.decorator";
+export * from "./get-data-filter-repository.token";

--- a/data-filter/lib/repositories/repository.factory.ts
+++ b/data-filter/lib/repositories/repository.factory.ts
@@ -1,0 +1,6 @@
+import { Type } from "@nestjs/common";
+import { DataFilterService } from "../data-filter.service";
+
+export function DataFilterRepositoryFactory<T>(options: { model: T }) {
+    return (dataFilterService: DataFilterService) => dataFilterService.for(options.model as Type<T>);
+}


### PR DESCRIPTION
There is currently no support to inject a data filter repository inside a nest module. This is particularly painful during our tests where there is no way to get a hold of an instance to be able to mock, for exemple. We end having to choose between a couple of options:

1. Mock the entire DataFilterService, which is kinda bad because all it does is return an instance of the repository. Also it kinda defeats the whole purpose of the test in the first place.
2. Do some weird trickery to mock dependencies of dependencies in order in order to achieve some result, which is also kinda bad because the resulting code is very fragile and not very clear.
3. Give up and cry and not test our code.

Let's assume that we go for the 4th option and do the right thing and actually test our code. Inside our modules, we can configure the classes of the repositories that should be injected, like so: 

```typescript
DataFilterModule.forFeature({
  ...
  repositories: [ModelData],
  ...
}),
``` 

and inside our services, we can inject these repositories, like so:  

```typescript
constructor(
  @InjectDataFilterRepository(ModelData) 
  private readonly modelDataRepository: DataFilterRepository<ModelData>
) {}
``` 

This allows us, inside our test files, to get access to the repository, like so:

```typescript
describe("MyService", () => {
  let modelDataRepository: DataFilterRepository<ModelData>;
  
  beforeAll(async () => {
    ...
    modelDataRepository = module.get(getDataFilterRepositoryToken(ModelData));
  });
  ...
});

``` 

Our mocks now get trivial to instantiate, and our resulting test code, much more clear.
