### PR TITLE
fix(sequelize-utils)!: read repository typings

### DIFF
--- a/sequelize-utils/lib/repositories/database-read-repository.ts
+++ b/sequelize-utils/lib/repositories/database-read-repository.ts
@@ -5,7 +5,7 @@ import { SequelizeEntities } from "../models/sequelize-entities.model";
 export abstract class SequelizeReadRepository<T extends SequelizeEntities> {
     protected abstract repository: typeof SequelizeEntities<any, any>;
 
-    public findByPk(identifier: Identifier, options?: FindOptions<Attributes<T>>): Promise<T | null> {
+    public findByPk(identifier: Identifier, options?: Omit<FindOptions<Attributes<T>>, "where">): Promise<T | null> {
         return this.repository.findByPk(identifier, options) as unknown as Promise<T | null>;
     }
 
@@ -17,7 +17,7 @@ export abstract class SequelizeReadRepository<T extends SequelizeEntities> {
         return this.repository.findAll(options) as unknown as Promise<T[]>;
     }
 
-    public count(options?: CountOptions<Attributes<T>>): Promise<number> {
+    public count(options?: Omit<CountOptions<Attributes<T>>, "group">): Promise<number> {
         return this.repository.count(options);
     }
 }

--- a/sequelize-utils/lib/repositories/database-repository.ts
+++ b/sequelize-utils/lib/repositories/database-repository.ts
@@ -16,12 +16,12 @@ export abstract class SequelizeRepository<T extends SequelizeEntities, CreateDto
         return this.repository.create(dto as any, options as any) as unknown as Promise<T>;
     }
 
-    public bulkCreate<Options>(dto: (CreateDto)[], options?: Options & BulkCreateOptions<Attributes<T>>): Promise<T[]> {
+    public bulkCreate<Options>(dto: CreateDto[], options?: Options & BulkCreateOptions<Attributes<T>>): Promise<T[]> {
         return this.repository.bulkCreate(dto as any, options as any) as unknown as Promise<T[]>;
     }
 
     public findOrCreate<Options>(options: FindOrCreateOptions, args?: Options): Promise<[T, boolean]> {
-        return (this.repository.findOrCreate(options)) as Promise<[T, boolean]>;
+        return this.repository.findOrCreate(options) as Promise<[T, boolean]>;
     }
 
     public async updateByPk<Options>(identifier: Identifier, dto: UpdateDto, options?: Options & UpdateOptions<Attributes<T>>): Promise<T | null> {
@@ -31,7 +31,7 @@ export abstract class SequelizeRepository<T extends SequelizeEntities, CreateDto
             },
             ...options as unknown as any
         });
-        return this.findByPk(identifier);
+        return this.findByPk(identifier, { transaction: options?.transaction });
     }
 
     public async update<Options>(dto: UpdateDto, options?: Options & UpdateOptions<Attributes<T>>): Promise<void> {

--- a/sequelize-utils/package-lock.json
+++ b/sequelize-utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@recursyve/nestjs-sequelize-utils",
-    "version": "9.3.3",
+    "version": "9.6.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@recursyve/nestjs-sequelize-utils",
-            "version": "9.3.3",
+            "version": "9.6.0",
             "license": "MIT",
             "devDependencies": {
                 "@nestjs/common": "^9.2.1",


### PR DESCRIPTION
Fix `findByPk` options signature.