### PR TITLE
Fix pour faire en sorte qu'on puisse filtrer par colonne json à l'aide du path

### DIFF
--- a/data-filter/lib/filter/filters/filter.ts
+++ b/data-filter/lib/filter/filters/filter.ts
@@ -358,7 +358,7 @@ export abstract class Filter implements FilterDefinition {
         const colName = this.path ? Sequelize.literal(SequelizeUtils.getLiteralFullName(this.attribute, this.path)) : Sequelize.col(this.attribute);
         const value = SequelizeUtils.generateWhereValue(rule);
         if (this.json.path) {
-            return Sequelize.where(Sequelize.fn("JSON_EXTRACT", colName, Sequelize.literal("$." + this.json.path)), value as LogicType);
+            return Sequelize.where(Sequelize.fn("JSON_EXTRACT", colName, Sequelize.literal(`'$.${this.json.path}'`)), value as LogicType);
         }
 
         return Sequelize.where(Sequelize.fn("JSON_EXTRACT", colName), value as LogicType);


### PR DESCRIPTION
Le where générer était
```
(JSON_EXTRACT(`attribute`.`config`, $.type) = 'integer')
```
ce qui n'est pas valide, maintenant: 
```
(JSON_EXTRACT(`attribute`.`config`, '$.type') = 'integer')
```