### PR TITLE
Remove unnecessary check for searchable translation attributes in getSearchTranslationAttributes method

### DIFF
--- a/data-filter/lib/data-filter.repository.ts
+++ b/data-filter/lib/data-filter.repository.ts
@@ -274,10 +274,6 @@ export class DataFilterRepository<Data> {
     }
 
     public getSearchTranslationAttributes(): SearchAttributesModel[] {
-        if (!this._config.getSearchableTranslationAttributes().length) {
-            return [];
-        }
-
         const attributes: SearchAttributesModel[] = [];
         const modelAttr = this._config.getSearchableTranslationAttributes();
         attributes.push(


### PR DESCRIPTION
The logic was flawed because it would short circuit when the model had no SearchTranslationAttributes, even when one of the nested fields had some SearchTranslationAttributes