### PR TITLE
fix(data-filter): ORDER BY incompatible avec SELECT DISTINCT sur MySQL

### DIFF
--- a/data-filter/lib/filter/filter.service.spec.ts
+++ b/data-filter/lib/filter/filter.service.spec.ts
@@ -18,6 +18,7 @@ import { BaseFilter } from "./base-filter";
 import { FilterService } from "./filter.service";
 import { NumberFilter, TextFilter } from "./filters";
 import { DefaultFilter } from "./filters/default.filter";
+import { DefaultOrderRule } from "./order-rules/default.order-rule";
 import { FilterOperatorTypes } from "./operators";
 
 @Data(ContractSystems)
@@ -306,5 +307,54 @@ describe("FilterService", () => {
                 ]
             }
         });
+    });
+});
+
+@Injectable()
+export class OrderByDistinctTestFilter extends BaseFilter<ContractSystemsTest> {
+    public dataDefinition = ContractSystemsTest;
+
+    public defaultOrderRule = new DefaultOrderRule({ column: "active", direction: "desc" });
+}
+
+describe("FilterService resolveOrderColumns", () => {
+    let filterService: FilterService<ContractSystemsTest>;
+
+    beforeAll(() => {
+        filterService = new FilterService<ContractSystemsTest>(
+            new DefaultAccessControlAdapter(),
+            new DefaultTranslateAdapter(),
+            new OrderByDistinctTestFilter(),
+            new SequelizeModelScanner(),
+            new DataFilterService(
+                new DataFilterScanner(),
+                new SequelizeModelScanner(),
+                new DefaultAccessControlAdapter(),
+                new DefaultTranslateAdapter(),
+                new DefaultExportAdapter()
+            )
+        );
+    });
+
+    it("merges defaultOrderRule when client order is empty", () => {
+        const service = filterService as unknown as {
+            resolveOrderColumns: (
+                orders: Array<{ column: string; direction: string }>
+            ) => Array<{ column: string; direction: string }>;
+        };
+
+        expect(service.resolveOrderColumns([])).toEqual([{ column: "active", direction: "desc" }]);
+    });
+
+    it("prefers explicit client order over defaultOrderRule for the same column", () => {
+        const service = filterService as unknown as {
+            resolveOrderColumns: (
+                orders: Array<{ column: string; direction: string }>
+            ) => Array<{ column: string; direction: string }>;
+        };
+
+        expect(service.resolveOrderColumns([{ column: "active", direction: "asc" }])).toEqual([
+            { column: "active", direction: "asc" }
+        ]);
     });
 });

--- a/data-filter/lib/filter/filter.service.ts
+++ b/data-filter/lib/filter/filter.service.ts
@@ -526,12 +526,16 @@ export class FilterService<Data> {
             options.where = await this.getAccessControlWhereCondition(options.where, user);
         }
 
-        const order = this.getOrderOptions(filter.order ?? [], { request, user });
-        const customAttributes = filter.order ? this.getOrderCustomAttribute(filter.order, filter.data) : [];
+        const orderContext: OrderRuleContext = { request, user };
+        const order = this.getOrderOptions(filter.order ?? [], orderContext);
+        const orderSelectAttributes = this.getOrderSelectAttributes(filter.order ?? [], orderContext, filter.data);
 
         const values = await repository.model.findAll({
             ...options,
-            attributes: [[Sequelize.literal(`DISTINCT \`${this.repository.model.name}\`.\`id\``), "id"], ...customAttributes],
+            attributes: [
+                [Sequelize.literal(`DISTINCT \`${this.repository.model.name}\`.\`id\``), "id"],
+                ...orderSelectAttributes
+            ],
             limit: filter.page?.size,
             offset: filter.page ? filter.page.number * filter.page.size + (filter.page.offset ?? 0) : undefined,
             subQuery: false,
@@ -616,19 +620,26 @@ export class FilterService<Data> {
         ];
     }
 
-    private getOrderOptions(orders: OrderModel | OrderModel[], context: OrderRuleContext): Order {
-        let orderColumns = Array.isArray(orders) ? orders : [orders];
+    private resolveOrderColumns(orders: OrderModel | OrderModel[]): OrderModel[] {
+        let orderColumns = Array.isArray(orders) ? [...orders] : [orders];
 
         if (this.model.defaultOrderRule) {
             const defaultOrders = Array.isArray(this.model.defaultOrderRule.order)
                 ? this.model.defaultOrderRule.order
                 : [this.model.defaultOrderRule.order];
 
-            const applicableDefaultOrderRule = defaultOrders.filter((order) => !orderColumns.some((o) => o.column === order.column));
+            const applicableDefaultOrderRule = defaultOrders.filter(
+                (order) => !orderColumns.some((o) => o.column === order.column)
+            );
 
             orderColumns = [...applicableDefaultOrderRule, ...orderColumns];
         }
 
+        return orderColumns.filter((order) => order?.column && order.direction);
+    }
+
+    private getOrderOptions(orders: OrderModel | OrderModel[], context: OrderRuleContext): Order {
+        const orderColumns = this.resolveOrderColumns(orders);
         const generatedOrder: Order = [];
 
         for (const order of orderColumns) {
@@ -671,6 +682,46 @@ export class FilterService<Data> {
                 attributes.push(attribute);
             }
         }
+        return attributes;
+    }
+
+    private getOrderSelectAttributes(
+        orders: OrderModel | OrderModel[],
+        context: OrderRuleContext,
+        data?: object
+    ): ProjectionAlias[] {
+        const orderColumns = this.resolveOrderColumns(orders);
+        const attributes: ProjectionAlias[] = [];
+        const seenColumns = new Set<string>();
+
+        for (const order of orderColumns) {
+            if (!order.column || order.column === "id" || seenColumns.has(order.column)) {
+                continue;
+            }
+
+            seenColumns.add(order.column);
+
+            if (this.repository.hasCustomAttribute(order.column)) {
+                const customAttribute = this.repository.getCustomAttribute(order.column);
+                const attribute = customAttribute?.transform(data) as ProjectionAlias;
+                if (attribute) {
+                    attributes.push(attribute);
+                }
+                continue;
+            }
+
+            const rule = this.definitions[order.column] as OrderRuleDefinition;
+            if (rule && OrderRule.validate(rule)) {
+                attributes.push([rule.getOrderOption(this.repository.model, context), order.column]);
+                continue;
+            }
+
+            const columnLiteral = this.sequelizeModelScanner.getOrderColumnLiteral(this.repository.model, order);
+            if (columnLiteral) {
+                attributes.push([literal(columnLiteral), order.column]);
+            }
+        }
+
         return attributes;
     }
 

--- a/data-filter/lib/scanners/sequelize-model.scanner.ts
+++ b/data-filter/lib/scanners/sequelize-model.scanner.ts
@@ -149,21 +149,33 @@ export class SequelizeModelScanner {
         return result;
     }
 
+    public getOrderColumnLiteral(model: typeof Model, orderObj: OrderModel): string | undefined {
+        if (!orderObj?.column) {
+            return;
+        }
+
+        const pathSegments = orderObj.column.split(".");
+        const column = pathSegments.pop() as string;
+        for (const segment of pathSegments) {
+            const association = this.findAssociation(model, segment);
+            model = association.getAssociatedClass() as unknown as typeof Model;
+        }
+
+        const col = SequelizeUtils.findColumnFieldName(model as typeof M, column);
+        return pathSegments.length
+            ? SequelizeUtils.getLiteralFullName(col, pathSegments)
+            : `\`${model.name}\`.\`${col}\``;
+    }
+
     public getOrder(model: typeof Model, orderObj: OrderModel): Order | undefined {
         if (!orderObj?.column || !orderObj.direction) {
             return;
         }
 
-        const values = orderObj.column.split(".");
-        const column = values.pop() as string;
-        for (const value of values) {
-            const association = this.findAssociation(model, value);
-            model = association.getAssociatedClass() as unknown as typeof Model;
+        let literalOrder = this.getOrderColumnLiteral(model, orderObj);
+        if (!literalOrder) {
+            return;
         }
-        const col = SequelizeUtils.findColumnFieldName(model as typeof M, column);
-        let literalOrder = values.length ?
-            SequelizeUtils.getLiteralFullName(col, values) :
-            `\`${model.name}\`.\`${col}\``;
 
         if (orderObj.nullLast) {
             literalOrder = `-${literalOrder}`;


### PR DESCRIPTION
## Résumé

Corrige l'erreur MySQL `ER_FIELD_IN_ORDER_NOT_SELECT` (3065) dans `FilterService.findValues()` lorsque la pagination par `SELECT DISTINCT id` est combinée avec un `ORDER BY` sur des colonnes absentes du `SELECT`.

- Enrichit le `SELECT DISTINCT` avec toutes les colonnes de l'ordre effectif (colonnes modèle, règles d'ordre, attributs custom).
- Prend en compte `defaultOrderRule` dans la résolution des colonnes d'ordre (auparavant appliqué au `ORDER BY` mais pas au `SELECT`).
- Extrait `getOrderColumnLiteral()` dans `SequelizeModelScanner` pour réutiliser la qualification des colonnes.

## Contexte / bug

Exemple de requête qui échouait sous MySQL 8 avec `ONLY_FULL_GROUP_BY` :

```sql
SELECT DISTINCT `Model`.`id` AS `id`
FROM `transactions` AS `Model`
ORDER BY `Model`.`occurred_at` DESC, `Model`.`id` DESC
LIMIT 0, 10;
```

`occurred_at` était présent dans `ORDER BY` mais pas dans le `SELECT` → MySQL refuse.

## Test plan

- [x] `npm test -- --testPathPattern=filter.service.spec --testNamePattern=resolveOrderColumns`
- [ ] Vérifier en consommateur : filtre avec `order: [{ column: "occurredAt", direction: "desc" }]` sur MySQL 8 strict
- [ ] Vérifier un filtre avec `defaultOrderRule` seul et `filter.order` vide